### PR TITLE
Add GoogleService::Sheet#write_csv (ユーザー所有スプレッドシートへのCSV書き込み)

### DIFF
--- a/lib/google_service/connection.rb
+++ b/lib/google_service/connection.rb
@@ -25,6 +25,22 @@ class GoogleService::Connection
     drive.list_files q: query, fields: "files(id, kind, mime_type, name, createdTime, modifiedTime)"
   end
 
+  # CSVファイルをGoogleスプレッドシートに変換してfolder_id直下に作成する。
+  # 0バイトのCSVは変換アップロードできないため、空のスプレッドシートを作成する。
+  def create_spreadsheet_from_csv(folder_id:, name:, csv_path:)
+    metadata = Google::Apis::DriveV3::File.new(
+      name: name,
+      mime_type: "application/vnd.google-apps.spreadsheet",
+      parents: [ folder_id ])
+    params = {
+      supports_all_drives: true,
+      fields: "id, kind, mime_type, name, createdTime, modifiedTime"
+    }
+    params.update(upload_source: csv_path.to_s, content_type: "text/csv") unless ::File.size(csv_path).zero?
+    meta = drive.create_file(metadata, **params)
+    GoogleService::ObjectSelector.from(meta, service: self)
+  end
+
   def drive
     @drive ||= begin
       authorizer = new_authorizer
@@ -76,7 +92,7 @@ class GoogleService::Connection
       Google::Auth::ServiceAccountCredentials.
         make_creds(
           json_key_io: service_account_credential_io,
-          scope: Google::Apis::DriveV3::AUTH_DRIVE_READONLY)
+          scope: Google::Apis::DriveV3::AUTH_DRIVE)
     end
 
     def uri_from(uri_or_string)

--- a/spec/lib/google_service/connection_spec.rb
+++ b/spec/lib/google_service/connection_spec.rb
@@ -59,4 +59,52 @@ RSpec.describe GoogleService::Connection, type: :model do
     # no url returns nil
     expect(conn.send(:file_id_from_uri, "(12345)")).to be_nil
   end
+
+  describe '#create_spreadsheet_from_csv' do
+    let(:conn) { GoogleService::Connection.new }
+    let(:drive) { instance_double(Google::Apis::DriveV3::DriveService) }
+    let(:meta) do
+      Google::Apis::DriveV3::File.new(
+        id: "1createdKey",
+        mime_type: "application/vnd.google-apps.spreadsheet",
+        name: "test-sheet")
+    end
+
+    before { allow(conn).to receive(:drive).and_return(drive) }
+
+    it 'uploads csv content converted to a spreadsheet in the folder' do
+      Tempfile.create(%w[students .csv]) do |f|
+        f.write("No,学籍番号,氏名\n1,2400000000,山田 太郎\n")
+        f.flush
+
+        expect(drive).to receive(:create_file) do |file_metadata, **params|
+          expect(file_metadata.name).to eq "test-sheet"
+          expect(file_metadata.mime_type).to eq "application/vnd.google-apps.spreadsheet"
+          expect(file_metadata.parents).to eq [ "1folderKey" ]
+          expect(params[:upload_source]).to eq f.path
+          expect(params[:content_type]).to eq "text/csv"
+          expect(params[:supports_all_drives]).to be true
+          meta
+        end
+
+        object = conn.create_spreadsheet_from_csv(folder_id: "1folderKey", name: "test-sheet", csv_path: f.path)
+        expect(object).to be_a GoogleService::Sheet
+        expect(object.id).to eq "1createdKey"
+      end
+    end
+
+    it 'creates an empty spreadsheet for a zero-byte csv' do
+      Tempfile.create(%w[empty .csv]) do |f|
+        expect(drive).to receive(:create_file) do |file_metadata, **params|
+          expect(file_metadata.parents).to eq [ "1folderKey" ]
+          expect(params).not_to have_key(:upload_source)
+          expect(params).not_to have_key(:content_type)
+          meta
+        end
+
+        object = conn.create_spreadsheet_from_csv(folder_id: "1folderKey", name: "test-sheet", csv_path: f.path)
+        expect(object).to be_a GoogleService::Sheet
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

当初はservice accountでスプレッドシートを新規作成する方式だったが、2025年4月のGoogle仕様変更によりSAはマイドライブ領域にファイルを作成できない(`storageQuotaExceeded`)ことが判明。**ユーザーが作成・共有した既存スプレッドシートにSAが書き込む方式**に変更した。

- `GoogleService::Sheet#write_csv(csv_path, sheet_title: nil)` を追加
  - 省略時は先頭シートに書き込み。指定シートがなければ追加
  - 書き込み前に既存値をクリアして上書き
  - 0バイトCSVはクリアのみ(空シートになる)
- `GoogleService::Sheet#sheet_titles` を追加
- 認可スコープを `drive.readonly` → `drive` に変更(Sheets書き込みに必要)
- Ruby 3.4対応: `csv` gemをGemfileに明示

## 利用前提

書き込み先スプレッドシートをユーザーが作成し、service accountの `client_email` に**編集者**として共有しておくこと(SA共有済みフォルダ内に作成すれば継承される)。

## 使い方

```ruby
conn = GoogleService::Connection.new
sheet = conn.object_from_url("https://docs.google.com/spreadsheets/d/xxxx/edit")
sheet.write_csv("path/to/2026-ss-pg1-1-S55820201A.csv")
```

## Test plan

- [x] `spec/lib/google_service/sheet_spec.rb` 追加(デフォルトシート書き込み / シート追加 / 0バイトCSV) — 4 examples, 0 failures
- [x] rubocop no offenses
- [ ] 共有済みスプレッドシートでの実機動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)